### PR TITLE
terraform: Use default Cilium version

### DIFF
--- a/contrib/terraform/libvirt/deploy-kubernetes.sh
+++ b/contrib/terraform/libvirt/deploy-kubernetes.sh
@@ -14,8 +14,6 @@ fi
 
 sleep 5
 
-CILIUM_VERSION=$(curl -s https://api.github.com/repos/cilium/cilium/releases/latest | jq -r '.tag_name' | sed -e 's/^v//')
-
 info "### Run following commands to bootstrap Kubernetes cluster:\\n"
 
 i=0
@@ -29,7 +27,7 @@ for MASTER in $TR_MASTER_IPS; do
           sudo cp /etc/kubernetes/admin.conf /home/${TR_USERNAME}/.kube/config
           sudo chown ${TR_USERNAME}:users /home/${TR_USERNAME}/.kube/config
           helm repo add cilium https://helm.cilium.io/
-          helm install cilium cilium/cilium --version ${CILIUM_VERSION} --namespace kube-system --set kubeProxyReplacement=disabled
+          helm install cilium cilium/cilium --namespace kube-system --set kubeProxyReplacement=disabled
 EOF
 
         export KUBEADM_MASTER_JOIN=`ssh -o 'StrictHostKeyChecking no' -l ${TR_USERNAME} ${MASTER} tail -n12 kubeadm-init.log | head -n3`

--- a/contrib/terraform/openstack/deploy-kubernetes.sh
+++ b/contrib/terraform/openstack/deploy-kubernetes.sh
@@ -15,8 +15,6 @@ fi
 
 sleep 5
 
-CILIUM_VERSION=$(curl -s https://api.github.com/repos/cilium/cilium/releases/latest | jq -r '.tag_name' | sed -e 's/^v//')
-
 info "### Run following commands to bootstrap Kubernetes cluster:\\n"
 
 i=0
@@ -30,7 +28,7 @@ for MASTER in $TR_MASTER_IPS; do
           sudo cp /etc/kubernetes/admin.conf /home/${TR_USERNAME}/.kube/config
           sudo chown ${TR_USERNAME}:users /home/${TR_USERNAME}/.kube/config
           helm repo add cilium https://helm.cilium.io/
-          helm install cilium cilium/cilium --version ${CILIUM_VERSION} --namespace kube-system --set kubeProxyReplacement=disabled
+          helm install cilium cilium/cilium --namespace kube-system --set kubeProxyReplacement=disabled
 EOF
 
         export KUBEADM_MASTER_JOIN=`ssh -o 'StrictHostKeyChecking no' -l ${TR_USERNAME} ${MASTER} tail -n12 kubeadm-init.log | head -n3`


### PR DESCRIPTION
The hack with getting Cilium version from Github API doesn't seem to
work anymore, but let's just stick to the default version in Cilium helm
repository.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>