### PR TITLE
Add file_open LSM program

### DIFF
--- a/lockc-common/src/lib.rs
+++ b/lockc-common/src/lib.rs
@@ -95,7 +95,7 @@ pub struct MountType {
 
 #[derive(Copy, Clone)]
 #[repr(C)]
-pub struct ContainerPath {
+pub struct Path {
     pub path: [u8; PATH_LEN],
 }
 

--- a/lockc-ebpf/Cargo.toml
+++ b/lockc-ebpf/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
 lockc-common = { path = "../lockc-common" }
-unroll = "0.1"
 
 [[bin]]
 name = "lockc"

--- a/lockc-ebpf/src/maps.rs
+++ b/lockc-ebpf/src/maps.rs
@@ -3,7 +3,7 @@ use aya_bpf::{
     maps::{HashMap, PerCpuArray},
 };
 
-use lockc_common::{Container, ContainerID, ContainerPath, MountType, Process, PID_MAX_LIMIT};
+use lockc_common::{Container, ContainerID, MountType, Path, Process, PID_MAX_LIMIT};
 
 /// BPF map containing the info about a policy which should be enforced on the
 /// given container.
@@ -26,5 +26,4 @@ pub(crate) static mut CONTAINER_INITIAL_SETUID: HashMap<ContainerID, bool> =
 pub(crate) static mut MOUNT_TYPE_BUF: PerCpuArray<MountType> = PerCpuArray::with_max_entries(1, 0);
 
 #[map]
-pub(crate) static mut CONTAINER_PATH_BUF: PerCpuArray<ContainerPath> =
-    PerCpuArray::with_max_entries(1, 0);
+pub(crate) static mut PATH_BUF: PerCpuArray<Path> = PerCpuArray::with_max_entries(1, 0);

--- a/lockc/src/load.rs
+++ b/lockc/src/load.rs
@@ -90,12 +90,12 @@ pub fn attach_programs(bpf: &mut Bpf) -> Result<(), AttachError> {
     program.load("task_fix_setuid", &btf)?;
     program.attach()?;
 
-    // let open_audit: &mut Lsm = bpf
-    //     .program_mut("file_open")
-    //     .ok_or(AttachError::ProgLoad)?
-    //     .try_into()?;
-    // open_audit.load("file_open", &btf)?;
-    // open_audit.attach()?;
+    let program: &mut Lsm = bpf
+        .program_mut("file_open")
+        .ok_or(AttachError::ProgLoad)?
+        .try_into()?;
+    program.load("file_open", &btf)?;
+    program.attach()?;
 
     Ok(())
 }


### PR DESCRIPTION
This program is trggered by opening a file and denies access to
directories which might leak information about host (/sys/fs, /proc/acpi
etc.).

Fixes: #139
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>