### PR TITLE
runc: Add k3s runc binaries to fanotify

### DIFF
--- a/lockc/Cargo.toml
+++ b/lockc/Cargo.toml
@@ -30,6 +30,7 @@ tracing = "0.1"
 tracing-core = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json"] }
+walkdir = "2.3"
 
 [dev-dependencies]
 tempfile = "3.3"


### PR DESCRIPTION
Looking for runc binary shipped with k3s is a bit trickier, because
it comes in the /var/lib/rancher/k3s/data/[ID] directory where ID is
random. We need to walk through /var/lib/rancher/k3s.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>