### PR TITLE
examples: Add example nginx deployments

### DIFF
--- a/examples/kubernetes/nginx-should-fail.yaml
+++ b/examples/kubernetes/nginx-should-fail.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-bad-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx-bad
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx-bad
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/examples/kubernetes/nginx-should-succeed.yaml
+++ b/examples/kubernetes/nginx-should-succeed.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: bitnami/nginx:1.20.2
+          ports:
+            - containerPort: 8080


### PR DESCRIPTION
One of them (the "standard" one ( ͡° ͜ʖ ͡°) ) is running as root, therefore
denied by lockc.

The other one, provided by bitnami, deploys successfully.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>