### PR TITLE
xtask: Add codegen subcommand

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 structopt = {version = "0.3", default-features = false }
+aya-gen = { git = "https://github.com/aya-rs/aya", branch = "main" }
 anyhow = "1"
 flate2 = "1.0"
 fs_extra = "1.2"

--- a/xtask/src/codegen.rs
+++ b/xtask/src/codegen.rs
@@ -1,0 +1,17 @@
+use std::{fs::File, io::Write, path::PathBuf};
+
+use aya_gen::generate::InputFile;
+
+pub fn generate() -> Result<(), anyhow::Error> {
+    let dir = PathBuf::from("lockc-ebpf/src");
+    let names: Vec<&str> = vec!["cred", "file"];
+    let bindings = aya_gen::generate(
+        InputFile::Btf(PathBuf::from("/sys/kernel/btf/vmlinux")),
+        &names,
+        &[],
+    )?;
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let mut out = File::create(dir.join("vmlinux.rs"))?;
+    write!(out, "{}", bindings)?;
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,5 +1,6 @@
 mod bintar;
 mod build_ebpf;
+mod codegen;
 mod install;
 mod run;
 
@@ -18,6 +19,7 @@ enum Command {
     BuildEbpf(build_ebpf::Options),
     Install(install::Options),
     Run(run::Options),
+    Codegen,
 }
 
 fn main() {
@@ -25,12 +27,11 @@ fn main() {
 
     use Command::*;
     let ret = match opts.command {
-        Bintar(opts) => {
-            bintar::BinTar::new(opts).do_bin_tar()
-        }
+        Bintar(opts) => bintar::BinTar::new(opts).do_bin_tar(),
         BuildEbpf(opts) => build_ebpf::build_ebpf(opts),
         Install(opts) => install::Installer::new(opts).do_install(),
         Run(opts) => run::run(opts),
+        Codegen => codegen::generate(),
     };
 
     if let Err(e) = ret {


### PR DESCRIPTION
This subcommand generates bindings for the kernel structures.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>